### PR TITLE
Refactor JSON parsing in HelperContract

### DIFF
--- a/test/helpers/HelperContract.sol
+++ b/test/helpers/HelperContract.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import {Test, console} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {IDiamondLoupe} from "@diamond/interfaces/IDiamondLoupe.sol";
 import {Facet} from "@diamond/libraries/constants/Types.sol";
 


### PR DESCRIPTION
Replace the usage of JSONParserLib with vm.parseJsonKeys for selector generation.