### PR TITLE
Refactor error handling with revert statements

### DIFF
--- a/src/Diamond.sol
+++ b/src/Diamond.sol
@@ -27,7 +27,7 @@ contract Diamond {
         bytes4 selector = msg.sig;
         // Lookup facet for function selector
         address facet = LibDiamond.diamondStorage().selectorToFacetAndPosition[selector].facetAddress;
-        require(facet != address(0), FunctionDoesNotExist(selector));
+        if (facet == address(0)) revert FunctionDoesNotExist(selector);
 
         assembly {
             // Copy calldata to memory


### PR DESCRIPTION
Replace `require` statements with `revert` for improved error handling in the Diamond contract and LibDiamond library. This change enhances clarity and consistency in error management.