### PR TITLE
Refactor Diamond.sol for performance and cleanliness

### DIFF
--- a/src/Diamond.sol
+++ b/src/Diamond.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.4;
 
 import {DiamondStorage, LibDiamond} from "@diamond/libraries/LibDiamond.sol";
 import {LibOwnableRoles} from "@diamond/libraries/LibOwnableRoles.sol";
-import {DiamondArgs, FacetCut, FacetCutAction} from "@diamond/libraries/types/DiamondTypes.sol";
+import {DiamondArgs, FacetCut} from "@diamond/libraries/types/DiamondTypes.sol";
 import {FunctionDoesNotExist} from "@diamond/libraries/errors/DiamondErrors.sol";
 
 /// @notice Implements EIP-2535 Diamond proxy pattern, allowing dynamic addition, replacement, and removal of facets

--- a/src/libraries/LibDiamond.sol
+++ b/src/libraries/LibDiamond.sol
@@ -86,7 +86,7 @@ library LibDiamond {
     function _diamondCut(FacetCut[] memory _facetCuts, address _init, bytes memory _calldata) internal {
         uint256 facetCutsLength = _facetCuts.length;
         if (facetCutsLength == 0) revert NoFacetsInDiamondCut();
-        for (uint256 facetIndex; facetIndex < facetCutsLength; facetIndex++) {
+        for (uint256 facetIndex; facetIndex < facetCutsLength;) {
             FacetCutAction action = _facetCuts[facetIndex].action;
             if (action == FacetCutAction.Add) {
                 _addFunctions(_facetCuts[facetIndex].facetAddress, _facetCuts[facetIndex].functionSelectors);
@@ -96,6 +96,9 @@ library LibDiamond {
                 _removeFunctions(_facetCuts[facetIndex].facetAddress, _facetCuts[facetIndex].functionSelectors);
             } else {
                 revert IncorrectFacetCutAction(uint8(action));
+            }
+            unchecked {
+                ++facetIndex;
             }
         }
         emit DiamondCut(_facetCuts, _init, _calldata);


### PR DESCRIPTION
Remove an unused import and optimize the for loop in the _diamondCut function for improved performance.