### PR TITLE
Add initializable Diamond pattern

### DIFF
--- a/script/DeployDiamond.s.sol
+++ b/script/DeployDiamond.s.sol
@@ -6,7 +6,9 @@ import {MockDiamond} from "@diamond-test/mocks/MockDiamond.sol";
 import {DiamondCutFacet} from "@diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "@diamond/facets/DiamondLoupeFacet.sol";
 import {OwnableRolesFacet} from "@diamond/facets/OwnableRolesFacet.sol";
-import {DiamondInit} from "@diamond/initializers/DiamondInit.sol";
+import {ERC165Init} from "@diamond/initializers/ERC165Init.sol";
+import {MultiInit} from "@diamond/initializers/MultiInit.sol";
+import {OwnableInit} from "@diamond/initializers/OwnableInit.sol";
 import {ContextLib} from "@diamond/libraries/ContextLib.sol";
 import {FacetCut, FacetCutAction} from "@diamond/libraries/DiamondLib.sol";
 import {Script} from "forge-std/Script.sol";
@@ -28,8 +30,10 @@ contract DeployDiamond is Script, GetSelectors {
         DiamondLoupeFacet diamondLoupeFacet = new DiamondLoupeFacet();
         OwnableRolesFacet ownableRolesFacet = new OwnableRolesFacet();
 
-        // Deploy ERC165 initializer contract
-        address diamondInit = address(new DiamondInit());
+        // Deploy initializer contracts
+        address multiInit = address(new MultiInit());
+        address ownableInit = address(new OwnableInit());
+        address erc165Init = address(new ERC165Init());
 
         // Create an array of FacetCut entries for standard facets
         FacetCut[] memory cut = new FacetCut[](3);
@@ -55,9 +59,21 @@ contract DeployDiamond is Script, GetSelectors {
             functionSelectors: _getSelectors("OwnableRolesFacet")
         });
 
+        // Build MultiInit arrays for granular initialization
+        address[] memory initAddresses = new address[](2);
+        bytes[] memory initData = new bytes[](2);
+
+        initAddresses[0] = ownableInit;
+        initData[0] = abi.encodeWithSignature("initOwner(address)", ContextLib.msgSender());
+
+        initAddresses[1] = erc165Init;
+        initData[1] = abi.encodeWithSignature("initERC165()");
+
         // Deploy the Diamond contract with the facets and initialization args
-        MockDiamond diamond =
-            new MockDiamond(cut, diamondInit, abi.encodeWithSignature("initDiamond(address)", ContextLib.msgSender()));
+        MockDiamond diamond = new MockDiamond();
+        diamond.initialize(
+            cut, multiInit, abi.encodeWithSignature("multiInit(address[],bytes[])", initAddresses, initData)
+        );
         diamond_ = address(diamond);
         vm.stopBroadcast();
     }

--- a/src/Diamond.sol
+++ b/src/Diamond.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {DiamondLib, FacetCut} from "@diamond/libraries/DiamondLib.sol";
+import {InitializableLib} from "@diamond/libraries/InitializableLib.sol";
 
 /*
 ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀
@@ -32,21 +33,37 @@ import {DiamondLib, FacetCut} from "@diamond/libraries/DiamondLib.sol";
 
 /// @title Diamond
 /// @notice Implements ERC-2535 Diamond proxy pattern, allowing dynamic addition, replacement, and removal of facets
-/// @author Nick Mudge (https://github.com/mudgen/diamond-3-hardhat/blob/main/contracts/Diamond.sol)
-/// @author Modified by David Dada <daveproxy80@gmail.com> (https://github.com/dadadave80)
+/// @author David Dada <daveproxy80@gmail.com> (https://github.com/dadadave80)
+/// @author Modified from Nick Mudge (https://github.com/mudgen/diamond-3-hardhat/blob/main/contracts/Diamond.sol)
 abstract contract Diamond {
     /// @notice Initializes the Diamond proxy with the provided facets and initialization parameters
     /// @param _init Address of the initialization contract
     /// @param _calldata Calldata to be passed to the initialization contract
-    constructor(FacetCut[] memory _facetCuts, address _init, bytes memory _calldata) payable {
-        _diamondCut(_facetCuts, _init, _calldata);
+    function initialize(FacetCut[] calldata _facetCuts, address _init, bytes calldata _calldata)
+        external
+        payable
+        virtual
+    {
+        bytes32 s = InitializableLib.initializableSlot();
+        InitializableLib.preInitializer(s);
+
+        DiamondLib.diamondCutCalldata(_facetCuts, _init, _calldata);
+
+        InitializableLib.postInitializer(s);
     }
 
     /// @notice Fallback function that delegates calls to the appropriate facet based on function selector
     /// @dev Reads the facet address from diamond storage and performs a delegatecall; reverts if selector is not found
     fallback() external payable virtual {
-        _beforeDelegate();
         _delegate(_facet());
+    }
+
+    receive() external payable virtual {}
+
+    /// @notice Retrieves the implementation address for the current function call
+    /// @dev A Facet is one of many implementations in a Diamond Proxy
+    function _facet() internal view virtual returns (address) {
+        return DiamondLib.selectorToFacet(msg.sig);
     }
 
     /// @notice Internal function to perform a delegatecall to an implementation
@@ -71,20 +88,5 @@ abstract contract Diamond {
                 return(0, returndatasize())
             }
         }
-    }
-
-    /// @notice Internal function to perform a diamond cut
-    function _diamondCut(FacetCut[] memory _facetCuts, address _init, bytes memory _calldata) internal virtual {
-        DiamondLib.diamondCut(_facetCuts, _init, _calldata);
-    }
-
-    /// @notice Internal hook function to run before a delegatecall to the facet
-    /// @dev This function can be replaced to perform additional logic before the delegatecall
-    function _beforeDelegate() internal virtual {}
-
-    /// @notice Retrieves the implementation address for the current function call
-    /// @dev A Facet is one of many implementations in a Diamond Proxy
-    function _facet() internal view virtual returns (address) {
-        return DiamondLib.selectorToFacet(msg.sig);
     }
 }

--- a/src/facets/DiamondCutFacet.sol
+++ b/src/facets/DiamondCutFacet.sol
@@ -22,7 +22,7 @@ contract DiamondCutFacet is IDiamondCut {
     ///                  _calldata is executed with delegatecall on _init
     function diamondCut(FacetCut[] calldata _diamondCut, address _init, bytes calldata _calldata) external payable {
         // Check that the caller is the owner
-        OwnableRolesLib._checkOwner();
+        OwnableRolesLib.checkOwner();
         // Call the diamond cut function from the library
         DiamondLib.diamondCutCalldata(_diamondCut, _init, _calldata);
     }

--- a/src/facets/OwnableRolesFacet.sol
+++ b/src/facets/OwnableRolesFacet.sol
@@ -24,47 +24,47 @@ contract OwnableRolesFacet {
 
     /// @dev Allows the owner to transfer the ownership to `newOwner`.
     function transferOwnership(address _newOwner) public onlyOwner {
-        _newOwner._transferOwnership();
+        _newOwner.transferOwnership();
     }
 
     /// @dev Allows the owner to renounce their ownership.
     function renounceOwnership() public onlyOwner {
-        OwnableRolesLib._renounceOwnership();
+        OwnableRolesLib.renounceOwnership();
     }
 
     /// @dev Request a two-step ownership handover to the caller.
     /// The request will automatically expire in 48 hours (172800 seconds) by default.
     function requestOwnershipHandover() public {
-        OwnableRolesLib._requestOwnershipHandover();
+        OwnableRolesLib.requestOwnershipHandover();
     }
 
     /// @dev Cancels the two-step ownership handover to the caller, if any.
     function cancelOwnershipHandover() public {
-        OwnableRolesLib._cancelOwnershipHandover();
+        OwnableRolesLib.cancelOwnershipHandover();
     }
 
     /// @dev Allows the owner to complete the two-step ownership handover to `pendingOwner`.
     /// Reverts if there is no existing ownership handover requested by `pendingOwner`.
     function completeOwnershipHandover(address _pendingOwner) public onlyOwner {
-        _pendingOwner._completeOwnershipHandover();
+        _pendingOwner.completeOwnershipHandover();
     }
 
     /// @dev Allows the owner to grant `user` `roles`.
     /// If the `user` already has a role, then it will be an no-op for the role.
     function grantRoles(address _user, uint256 _roles) public onlyOwner {
-        _user._grantRoles(_roles);
+        _user.grantRoles(_roles);
     }
 
     /// @dev Allows the owner to remove `user` `roles`.
     /// If the `user` does not have a role, then it will be an no-op for the role.
     function revokeRoles(address _user, uint256 _roles) public onlyOwner {
-        _user._removeRoles(_roles);
+        _user.removeRoles(_roles);
     }
 
     /// @dev Allow the caller to remove their own roles.
     /// If the caller does not have a role, then it will be an no-op for the role.
     function renounceRoles(uint256 _roles) public {
-        msg.sender._removeRoles(_roles);
+        msg.sender.removeRoles(_roles);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -73,41 +73,41 @@ contract OwnableRolesFacet {
 
     /// @dev Returns the owner of the contract.
     function owner() public view returns (address) {
-        return OwnableRolesLib._owner();
+        return OwnableRolesLib.owner();
     }
 
     /// @dev Returns the expiry timestamp for the two-step ownership handover to `pendingOwner`.
     function ownershipHandoverExpiresAt(address _pendingOwner) public view returns (uint256) {
-        return _pendingOwner._ownershipHandoverExpiresAt();
+        return _pendingOwner.ownershipHandoverExpiresAt();
     }
 
     /// @dev Returns the roles of `user`.
     function rolesOf(address _user) public view returns (uint256) {
-        return _user._rolesOf();
+        return _user.rolesOf();
     }
 
     /// @dev Returns whether `user` has any of `roles`.
     function hasAnyRole(address _user, uint256 _roles) public view returns (bool) {
-        return _user._rolesOf() & _roles != 0;
+        return _user.rolesOf() & _roles != 0;
     }
 
     /// @dev Returns whether `user` has all of `roles`.
     function hasAllRoles(address _user, uint256 _roles) public view returns (bool) {
-        return _user._rolesOf() & _roles == _roles;
+        return _user.rolesOf() & _roles == _roles;
     }
 
     /// @dev Convenience function to return a `roles` bitmap from an array of `ordinals`.
     /// This is meant for frontends like Etherscan, and is therefore not fully optimized.
     /// Not recommended to be called on-chain.
     function rolesFromOrdinals(uint8[] memory ordinals) external pure returns (uint256) {
-        return ordinals._rolesFromOrdinals();
+        return ordinals.rolesFromOrdinals();
     }
 
     /// @dev Convenience function to return an array of `ordinals` from the `roles` bitmap.
     /// This is meant for frontends like Etherscan, and is therefore not fully optimized.
     /// Not recommended to be called on-chain.
     function ordinalsFromRoles(uint256 roles) external pure returns (uint8[] memory) {
-        return roles._ordinalsFromRoles();
+        return roles.ordinalsFromRoles();
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -116,27 +116,27 @@ contract OwnableRolesFacet {
 
     /// @dev Marks a function as only callable by the owner.
     modifier onlyOwner() {
-        OwnableRolesLib._checkOwner();
+        OwnableRolesLib.checkOwner();
         _;
     }
 
     /// @dev Marks a function as only callable by an account with `roles`.
     modifier onlyRoles(uint256 _roles) {
-        OwnableRolesLib._checkRoles(_roles);
+        OwnableRolesLib.checkRoles(_roles);
         _;
     }
 
     /// @dev Marks a function as only callable by the owner or by an account
     ///      with `roles`. Checks for ownership first, then lazily checks for roles.
     modifier onlyOwnerOrRoles(uint256 _roles) {
-        OwnableRolesLib._checkOwnerOrRoles(_roles);
+        OwnableRolesLib.checkOwnerOrRoles(_roles);
         _;
     }
 
     /// @dev Marks a function as only callable by an account with `roles` or the owner.
     /// Checks for roles first, then lazily checks for ownership.
     modifier onlyRolesOrOwner(uint256 _roles) {
-        OwnableRolesLib._checkRolesOrOwner(_roles);
+        OwnableRolesLib.checkRolesOrOwner(_roles);
         _;
     }
 }

--- a/src/initializers/DiamondInit.sol
+++ b/src/initializers/DiamondInit.sol
@@ -5,18 +5,20 @@ import {DiamondLib, DiamondStorage} from "@diamond/libraries/DiamondLib.sol";
 import {OwnableRolesLib} from "@diamond/libraries/OwnableRolesLib.sol";
 
 /// @title DiamondInit
-/// @notice Provides an initializer to register standard interface support (ERC-165, ERC-173, IDiamondCut, IDiamondLoupe)
+/// @notice Provides a combined initializer to set up ownership and register standard interface support
 /// @author Nick Mudge (https://github.com/mudgen/diamond-3-hardhat/blob/main/contracts/Diamond.sol)
 /// @author Modified by David Dada <daveproxy80@gmail.com> (https://github.com/dadadave80)
 ///
-/// @dev Intended to be called as the `initDiamond` function in a diamond cut to set up ERC-165 interface IDs
+/// @dev Intended to be called as the `initDiamond` function in a diamond cut.
+///      For granular initialization, use OwnableInit and ERC165Init separately via MultiInit.
 contract DiamondInit {
-    /// @notice Initialize the contract with the ERC165 interface support.
+    /// @notice Initialize the contract owner and register standard diamond ERC-165 interface IDs.
     /// @dev This function is called during the diamond cut process to set up
     ///      the initial state of the contract.
+    /// @param _owner The address to set as the contract owner.
     function initDiamond(address _owner) public {
         // Initialize the owner
-        OwnableRolesLib._initializeOwner(_owner);
+        OwnableRolesLib.initializeOwner(_owner);
 
         DiamondStorage storage ds = DiamondLib.diamondStorage();
         /// @dev type(ERC165).interfaceId

--- a/src/initializers/ERC165Init.sol
+++ b/src/initializers/ERC165Init.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {DiamondLib, DiamondStorage} from "@diamond/libraries/DiamondLib.sol";
+
+/// @title ERC165Init
+/// @notice Provides an initializer to register standard diamond interface support (ERC-165, ERC-173, IDiamondCut, IDiamondLoupe)
+/// @author David Dada <daveproxy80@gmail.com> (https://github.com/dadadave80)
+///
+/// @dev Intended to be called as a standalone initializer via diamond cut or through MultiInit
+contract ERC165Init {
+    /// @notice Register standard diamond ERC-165 interface IDs.
+    /// @dev Sets support for ERC-165, ERC-173, IDiamondCut, and IDiamondLoupe.
+    function initERC165() public {
+        DiamondStorage storage ds = DiamondLib.diamondStorage();
+        /// @dev type(ERC165).interfaceId
+        ds.supportedInterfaces[0x01ffc9a7] = true;
+        /// @dev type(IERC173).interfaceId
+        ds.supportedInterfaces[0x7f5828d0] = true;
+        /// @dev type(IDiamondCut).interfaceId
+        ds.supportedInterfaces[0x1f931c1c] = true;
+        /// @dev type(IDiamondLoupe).interfaceId
+        ds.supportedInterfaces[0x48e2b093] = true;
+    }
+}

--- a/src/initializers/MultiInit.sol
+++ b/src/initializers/MultiInit.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {DiamondLib} from "@diamond/libraries/DiamondLib.sol";
-
 /// @notice Thrown when the length of the address array does not match the length of the calldata array.
 /// @dev Used in initializer logic to ensure one-to-one mapping between addresses and initialization calldata.
 error AddressAndCalldataLengthMismatch();
+error NoBytecodeAtAddress(address initAddress);
+error InitializeReverted(address initAddress, bytes initCalldata);
 
 contract MultiInit {
     function multiInit(address[] calldata _initAddresses, bytes[] calldata _initData) public {
@@ -15,7 +15,21 @@ contract MultiInit {
         }
 
         for (uint256 i; i < initAddressesLength; ++i) {
-            DiamondLib.initializeDiamondCut(_initAddresses[i], _initData[i]);
+            address initAddress = _initAddresses[i];
+            if (initAddress == address(0)) return;
+            if (initAddress.code.length == 0) revert NoBytecodeAtAddress(initAddress);
+            (bool success, bytes memory err) = initAddress.delegatecall(_initData[i]);
+            if (!success) {
+                if (err.length > 0) {
+                    // bubble up error
+                    assembly ("memory-safe") {
+                        let returndata_size := mload(err)
+                        revert(add(32, err), returndata_size)
+                    }
+                } else {
+                    revert InitializeReverted(initAddress, _initData[i]);
+                }
+            }
         }
     }
 }

--- a/src/initializers/OwnableInit.sol
+++ b/src/initializers/OwnableInit.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {OwnableRolesLib} from "@diamond/libraries/OwnableRolesLib.sol";
+
+/// @title OwnableInit
+/// @notice Provides an initializer to set the contract owner
+/// @author David Dada <daveproxy80@gmail.com> (https://github.com/dadadave80)
+///
+/// @dev Intended to be called as a standalone initializer via diamond cut or through MultiInit
+contract OwnableInit {
+    /// @notice Initialize the contract owner.
+    /// @dev This function is called during the diamond cut process to set up the owner.
+    /// @param _owner The address to set as the contract owner.
+    function initOwner(address _owner) public {
+        OwnableRolesLib.initializeOwner(_owner);
+    }
+}

--- a/src/libraries/InitializableLib.sol
+++ b/src/libraries/InitializableLib.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+/*                       CUSTOM ERRORS                        */
+/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+/// @dev The contract is already initialized.
+error InvalidInitialization();
+
+/// @dev The contract is not initializing.
+error NotInitializing();
+
+/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+/*                           EVENTS                           */
+/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+/// @dev Triggered when the contract has been initialized.
+event Initialized(uint64 version);
+
+/// @dev `keccak256(bytes("Initialized(uint64)"))`.
+bytes32 constant _INITIALIZED_EVENT_SIGNATURE = 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2;
+
+/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+/*                          STORAGE                           */
+/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+/// @dev The default initializable slot is given by:
+/// `bytes32(~uint256(uint32(bytes4(keccak256("_INITIALIZABLE_SLOT")))))`.
+///
+/// Bits Layout:
+/// - [0]     `initializing`
+/// - [1..64] `initializedVersion`
+bytes32 constant _INITIALIZABLE_SLOT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf601132;
+
+/// @notice Initializable mixin for the upgradeable contracts.
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/Initializable.sol)
+/// @author Modified from OpenZeppelin (https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/proxy/utils/Initializable.sol)
+library InitializableLib {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         OPERATIONS                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Override to return a non-zero custom storage slot if required.
+    function initializableSlot() internal pure returns (bytes32) {
+        return _INITIALIZABLE_SLOT;
+    }
+
+    /// @dev Guards an initializer function so that it can be invoked at most once.
+    ///
+    /// You can guard a function with `onlyInitializing` such that it can be called
+    /// through a function guarded with `initializer`.
+    ///
+    /// This is similar to `reinitializer(1)`, except that in the context of a constructor,
+    /// an `initializer` guarded function can be invoked multiple times.
+    /// This can be useful during testing and is not expected to be used in production.
+    ///
+    /// Emits an {Initialized} event.
+    modifier initializer() {
+        bytes32 s = initializableSlot();
+        preInitializer(s);
+        _;
+        postInitializer(s);
+    }
+
+    function preInitializer(bytes32 _initializableSlot) internal {
+        assembly ("memory-safe") {
+            let i := sload(_initializableSlot)
+            // Set `initializing` to 1, `initializedVersion` to 1.
+            sstore(_initializableSlot, 3)
+            // If `!(initializing == 0 && initializedVersion == 0)`.
+            if i {
+                // If `!(address(this).code.length == 0 && initializedVersion == 1)`.
+                if iszero(lt(extcodesize(address()), eq(shr(1, i), 1))) {
+                    mstore(0x00, 0xf92ee8a9) // `InvalidInitialization()`.
+                    revert(0x1c, 0x04)
+                }
+                _initializableSlot := shl(shl(255, i), _initializableSlot) // Skip initializing if `initializing == 1`.
+            }
+        }
+    }
+
+    function postInitializer(bytes32 _initializableSlot) internal {
+        assembly ("memory-safe") {
+            if _initializableSlot {
+                // Set `initializing` to 0, `initializedVersion` to 1.
+                sstore(_initializableSlot, 2)
+                // Emit the {Initialized} event.
+                mstore(0x20, 1)
+                log1(0x20, 0x20, _INITIALIZED_EVENT_SIGNATURE)
+            }
+        }
+    }
+
+    /// @dev Guards a reinitializer function so that it can be invoked at most once.
+    ///
+    /// You can guard a function with `onlyInitializing` such that it can be called
+    /// through a function guarded with `reinitializer`.
+    ///
+    /// Emits an {Initialized} event.
+    modifier reinitializer(uint64 _version) {
+        bytes32 s = initializableSlot();
+        preReinitializer(s, _version);
+        _;
+        postReinitializer(s, _version);
+    }
+
+    function preReinitializer(bytes32 _initializableSlot, uint64 _version) internal {
+        assembly ("memory-safe") {
+            // Clean upper bits, and shift left by 1 to make space for the initializing bit.
+            _version := shl(1, and(_version, 0xffffffffffffffff))
+            let i := sload(_initializableSlot)
+            // If `initializing == 1 || initializedVersion >= version`.
+            if iszero(lt(and(i, 1), lt(i, _version))) {
+                mstore(0x00, 0xf92ee8a9) // `InvalidInitialization()`.
+                revert(0x1c, 0x04)
+            }
+            // Set `initializing` to 1, `initializedVersion` to `version`.
+            sstore(_initializableSlot, or(1, _version))
+        }
+    }
+
+    function postReinitializer(bytes32 _initializableSlot, uint64 _version) internal {
+        assembly ("memory-safe") {
+            // Set `initializing` to 0, `initializedVersion` to `version`.
+            sstore(_initializableSlot, _version)
+            // Emit the {Initialized} event.
+            mstore(0x20, shr(1, _version))
+            log1(0x20, 0x20, _INITIALIZED_EVENT_SIGNATURE)
+        }
+    }
+
+    /// @dev Guards a function such that it can only be called in the scope
+    /// of a function guarded with `initializer` or `reinitializer`.
+    modifier onlyInitializing() {
+        checkInitializing(initializableSlot());
+        _;
+    }
+
+    /// @dev Reverts if the contract is not initializing.
+    function checkInitializing(bytes32 _initializableSlot) internal view {
+        assembly ("memory-safe") {
+            if iszero(and(1, sload(_initializableSlot))) {
+                mstore(0x00, 0xd7e6bcf8) // `NotInitializing()`.
+                revert(0x1c, 0x04)
+            }
+        }
+    }
+
+    /// @dev Locks any future initializations by setting the initialized version to `2**64 - 1`.
+    ///
+    /// Calling this in the constructor will prevent the contract from being initialized
+    /// or reinitialized. It is recommended to use this to lock implementation contracts
+    /// that are designed to be called through proxies.
+    ///
+    /// Emits an {Initialized} event the first time it is successfully called.
+    function disableInitializers(bytes32 _initializableSlot) internal {
+        assembly ("memory-safe") {
+            let i := sload(_initializableSlot)
+            if and(i, 1) {
+                mstore(0x00, 0xf92ee8a9) // `InvalidInitialization()`.
+                revert(0x1c, 0x04)
+            }
+            let uint64max := 0xffffffffffffffff
+            if iszero(eq(shr(1, i), uint64max)) {
+                // Set `initializing` to 0, `initializedVersion` to `2**64 - 1`.
+                sstore(_initializableSlot, shl(1, uint64max))
+                // Emit the {Initialized} event.
+                mstore(0x20, uint64max)
+                log1(0x20, 0x20, _INITIALIZED_EVENT_SIGNATURE)
+            }
+        }
+    }
+
+    /// @dev Returns the highest version that has been initialized.
+    function getInitializedVersion(bytes32 _initializableSlot) internal view returns (uint64 version_) {
+        assembly ("memory-safe") {
+            version_ := shr(1, sload(_initializableSlot))
+        }
+    }
+
+    /// @dev Returns whether the contract is currently initializing.
+    function isInitializing(bytes32 _initializableSlot) internal view returns (bool result_) {
+        assembly ("memory-safe") {
+            result_ := and(1, sload(_initializableSlot))
+        }
+    }
+}

--- a/src/libraries/InitializableLib.sol
+++ b/src/libraries/InitializableLib.sol
@@ -122,6 +122,8 @@ library InitializableLib {
 
     function postReinitializer(bytes32 _initializableSlot, uint64 _version) internal {
         assembly ("memory-safe") {
+            // Clean upper bits, and shift left by 1 to match storage layout.
+            _version := shl(1, and(_version, 0xffffffffffffffff))
             // Set `initializing` to 0, `initializedVersion` to `version`.
             sstore(_initializableSlot, _version)
             // Emit the {Initialized} event.

--- a/src/libraries/OwnableRolesLib.sol
+++ b/src/libraries/OwnableRolesLib.sol
@@ -101,11 +101,6 @@ library OwnableRolesLib {
     /*                     INTERNAL FUNCTIONS                     */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-    /// @dev Override to return true to make `_initializeOwner` prevent double-initialization.
-    function _guardInitializeOwner() internal pure returns (bool) {
-        return true;
-    }
-
     /// @dev Initializes the owner directly without authorization guard.
     /// This function must be called upon initialization,
     /// regardless of whether the contract is upgradeable or not.
@@ -113,66 +108,38 @@ library OwnableRolesLib {
     /// and to save gas in case the initial owner is not the caller.
     /// For performance reasons, this function will not check if there
     /// is an existing owner.
-    function _initializeOwner(address newOwner) internal {
-        if (_guardInitializeOwner()) {
-            /// @solidity memory-safe-assembly
-            assembly {
-                let ownerSlot := _OWNER_SLOT
-                if sload(ownerSlot) {
-                    mstore(0x00, 0x0dc149f0) // `AlreadyInitialized()`.
-                    revert(0x1c, 0x04)
-                }
-                // Clean the upper 96 bits.
-                newOwner := shr(96, shl(96, newOwner))
-                // Store the new value.
-                sstore(ownerSlot, or(newOwner, shl(255, iszero(newOwner))))
-                // Emit the {OwnershipTransferred} event.
-                log3(0, 0, _OWNERSHIP_TRANSFERRED_EVENT_SIGNATURE, 0, newOwner)
+    function initializeOwner(address newOwner) internal {
+        assembly ("memory-safe") {
+            let ownerSlot := _OWNER_SLOT
+            if sload(ownerSlot) {
+                mstore(0x00, 0x0dc149f0) // `AlreadyInitialized()`.
+                revert(0x1c, 0x04)
             }
-        } else {
-            /// @solidity memory-safe-assembly
-            assembly {
-                // Clean the upper 96 bits.
-                newOwner := shr(96, shl(96, newOwner))
-                // Store the new value.
-                sstore(_OWNER_SLOT, newOwner)
-                // Emit the {OwnershipTransferred} event.
-                log3(0, 0, _OWNERSHIP_TRANSFERRED_EVENT_SIGNATURE, 0, newOwner)
-            }
+            // Clean the upper 96 bits.
+            newOwner := shr(96, shl(96, newOwner))
+            // Store the new value.
+            sstore(ownerSlot, or(newOwner, shl(255, iszero(newOwner))))
+            // Emit the {OwnershipTransferred} event.
+            log3(0, 0, _OWNERSHIP_TRANSFERRED_EVENT_SIGNATURE, 0, newOwner)
         }
     }
 
     /// @dev Sets the owner directly without authorization guard.
-    function _setOwner(address newOwner) internal {
-        if (_guardInitializeOwner()) {
-            /// @solidity memory-safe-assembly
-            assembly {
-                let ownerSlot := _OWNER_SLOT
-                // Clean the upper 96 bits.
-                newOwner := shr(96, shl(96, newOwner))
-                // Emit the {OwnershipTransferred} event.
-                log3(0, 0, _OWNERSHIP_TRANSFERRED_EVENT_SIGNATURE, sload(ownerSlot), newOwner)
-                // Store the new value.
-                sstore(ownerSlot, or(newOwner, shl(255, iszero(newOwner))))
-            }
-        } else {
-            /// @solidity memory-safe-assembly
-            assembly {
-                let ownerSlot := _OWNER_SLOT
-                // Clean the upper 96 bits.
-                newOwner := shr(96, shl(96, newOwner))
-                // Emit the {OwnershipTransferred} event.
-                log3(0, 0, _OWNERSHIP_TRANSFERRED_EVENT_SIGNATURE, sload(ownerSlot), newOwner)
-                // Store the new value.
-                sstore(ownerSlot, newOwner)
-            }
+    function setOwner(address newOwner) internal {
+        assembly ("memory-safe") {
+            let ownerSlot := _OWNER_SLOT
+            // Clean the upper 96 bits.
+            newOwner := shr(96, shl(96, newOwner))
+            // Emit the {OwnershipTransferred} event.
+            log3(0, 0, _OWNERSHIP_TRANSFERRED_EVENT_SIGNATURE, sload(ownerSlot), newOwner)
+            // Store the new value.
+            sstore(ownerSlot, or(newOwner, shl(255, iszero(newOwner))))
         }
     }
 
     /// @dev Throws if the sender is not the owner.
-    function _checkOwner() internal view {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function checkOwner() internal view {
+        assembly ("memory-safe") {
             // If the caller is not the stored owner, revert.
             if iszero(eq(caller(), sload(_OWNER_SLOT))) {
                 mstore(0x00, 0x82b42900) // `Unauthorized()`.
@@ -184,14 +151,13 @@ library OwnableRolesLib {
     /// @dev Returns how long a two-step ownership handover is valid for in seconds.
     /// Override to return a different value if needed.
     /// Made internal to conserve bytecode. Wrap it in a public function if needed.
-    function _ownershipHandoverValidFor() internal pure returns (uint64) {
+    function ownershipHandoverValidFor() internal pure returns (uint64) {
         return 48 * 3600;
     }
 
     /// @dev Overwrite the roles directly without authorization guard.
-    function _setRoles(address user, uint256 roles) internal {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function setRoles(address user, uint256 roles) internal {
+        assembly ("memory-safe") {
             mstore(0x0c, _ROLE_SLOT_SEED)
             mstore(0x00, user)
             // Store the new value.
@@ -204,9 +170,8 @@ library OwnableRolesLib {
     /// @dev Updates the roles directly without authorization guard.
     /// If `on` is true, each set bit of `roles` will be turned on,
     /// otherwise, each set bit of `roles` will be turned off.
-    function _updateRoles(address user, uint256 roles, bool on) internal {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function updateRoles(address user, uint256 roles, bool on) internal {
+        assembly ("memory-safe") {
             mstore(0x0c, _ROLE_SLOT_SEED)
             mstore(0x00, user)
             let roleSlot := keccak256(0x0c, 0x20)
@@ -229,20 +194,19 @@ library OwnableRolesLib {
 
     /// @dev Grants the roles directly without authorization guard.
     /// Each bit of `roles` represents the role to turn on.
-    function _grantRoles(address user, uint256 roles) internal {
-        _updateRoles(user, roles, true);
+    function grantRoles(address user, uint256 roles) internal {
+        updateRoles(user, roles, true);
     }
 
     /// @dev Removes the roles directly without authorization guard.
     /// Each bit of `roles` represents the role to turn off.
-    function _removeRoles(address user, uint256 roles) internal {
-        _updateRoles(user, roles, false);
+    function removeRoles(address user, uint256 roles) internal {
+        updateRoles(user, roles, false);
     }
 
     /// @dev Throws if the sender does not have any of the `roles`.
-    function _checkRoles(uint256 roles) internal view {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function checkRoles(uint256 roles) internal view {
+        assembly ("memory-safe") {
             // Compute the role slot.
             mstore(0x0c, _ROLE_SLOT_SEED)
             mstore(0x00, caller())
@@ -258,9 +222,8 @@ library OwnableRolesLib {
     /// @dev Throws if the sender is not the owner,
     /// and does not have any of the `roles`.
     /// Checks for ownership first, then lazily checks for roles.
-    function _checkOwnerOrRoles(uint256 roles) internal view {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function checkOwnerOrRoles(uint256 roles) internal view {
+        assembly ("memory-safe") {
             // If the caller is not the stored owner.
             // Note: `_ROLE_SLOT_SEED` is equal to `_OWNER_SLOT_NOT`.
             if iszero(eq(caller(), sload(not(_ROLE_SLOT_SEED)))) {
@@ -280,9 +243,8 @@ library OwnableRolesLib {
     /// @dev Throws if the sender does not have any of the `roles`,
     /// and is not the owner.
     /// Checks for roles first, then lazily checks for ownership.
-    function _checkRolesOrOwner(uint256 roles) internal view {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function checkRolesOrOwner(uint256 roles) internal view {
+        assembly ("memory-safe") {
             // Compute the role slot.
             mstore(0x0c, _ROLE_SLOT_SEED)
             mstore(0x00, caller())
@@ -303,9 +265,8 @@ library OwnableRolesLib {
     /// This is meant for frontends like Etherscan, and is therefore not fully optimized.
     /// Not recommended to be called on-chain.
     /// Made internal to conserve bytecode. Wrap it in a public function if needed.
-    function _rolesFromOrdinals(uint8[] memory ordinals) internal pure returns (uint256 roles) {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function rolesFromOrdinals(uint8[] memory ordinals) internal pure returns (uint256 roles) {
+        assembly ("memory-safe") {
             for {
                 let i := shl(5, mload(ordinals))
             } i {
@@ -322,9 +283,8 @@ library OwnableRolesLib {
     /// This is meant for frontends like Etherscan, and is therefore not fully optimized.
     /// Not recommended to be called on-chain.
     /// Made internal to conserve bytecode. Wrap it in a public function if needed.
-    function _ordinalsFromRoles(uint256 roles) internal pure returns (uint8[] memory ordinals) {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function ordinalsFromRoles(uint256 roles) internal pure returns (uint8[] memory ordinals) {
+        assembly ("memory-safe") {
             // Grab the pointer to the free memory.
             ordinals := mload(0x40)
             let ptr := add(ordinals, 0x20)
@@ -356,29 +316,27 @@ library OwnableRolesLib {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @dev Allows the owner to transfer the ownership to `newOwner`.
-    function _transferOwnership(address newOwner) internal {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function transferOwnership(address newOwner) internal {
+        assembly ("memory-safe") {
             if iszero(shl(96, newOwner)) {
                 mstore(0x00, 0x7448fbae) // `NewOwnerIsZeroAddress()`.
                 revert(0x1c, 0x04)
             }
         }
-        _setOwner(newOwner);
+        setOwner(newOwner);
     }
 
     /// @dev Allows the owner to renounce their ownership.
-    function _renounceOwnership() internal {
-        _setOwner(address(0));
+    function renounceOwnership() internal {
+        setOwner(address(0));
     }
 
     /// @dev Request a two-step ownership handover to the caller.
     /// The request will automatically expire in 48 hours (172800 seconds) by default.
-    function _requestOwnershipHandover() internal {
+    function requestOwnershipHandover() internal {
         unchecked {
-            uint256 expires = block.timestamp + _ownershipHandoverValidFor();
-            /// @solidity memory-safe-assembly
-            assembly {
+            uint256 expires = block.timestamp + ownershipHandoverValidFor();
+            assembly ("memory-safe") {
                 // Compute and set the handover slot to `expires`.
                 mstore(0x0c, _HANDOVER_SLOT_SEED)
                 mstore(0x00, caller())
@@ -390,9 +348,8 @@ library OwnableRolesLib {
     }
 
     /// @dev Cancels the two-step ownership handover to the caller, if any.
-    function _cancelOwnershipHandover() internal {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function cancelOwnershipHandover() internal {
+        assembly ("memory-safe") {
             // Compute and set the handover slot to 0.
             mstore(0x0c, _HANDOVER_SLOT_SEED)
             mstore(0x00, caller())
@@ -404,9 +361,8 @@ library OwnableRolesLib {
 
     /// @dev Allows the owner to complete the two-step ownership handover to `pendingOwner`.
     /// Reverts if there is no existing ownership handover requested by `pendingOwner`.
-    function _completeOwnershipHandover(address pendingOwner) internal {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function completeOwnershipHandover(address pendingOwner) internal {
+        assembly ("memory-safe") {
             // Compute and set the handover slot to 0.
             mstore(0x0c, _HANDOVER_SLOT_SEED)
             mstore(0x00, pendingOwner)
@@ -419,7 +375,7 @@ library OwnableRolesLib {
             // Set the handover slot to 0.
             sstore(handoverSlot, 0)
         }
-        _setOwner(pendingOwner);
+        setOwner(pendingOwner);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -427,17 +383,15 @@ library OwnableRolesLib {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @dev Returns the owner of the contract.
-    function _owner() internal view returns (address result) {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function owner() internal view returns (address result) {
+        assembly ("memory-safe") {
             result := sload(_OWNER_SLOT)
         }
     }
 
     /// @dev Returns the expiry timestamp for the two-step ownership handover to `pendingOwner`.
-    function _ownershipHandoverExpiresAt(address pendingOwner) internal view returns (uint256 result) {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function ownershipHandoverExpiresAt(address pendingOwner) internal view returns (uint256 result) {
+        assembly ("memory-safe") {
             // Compute the handover slot.
             mstore(0x0c, _HANDOVER_SLOT_SEED)
             mstore(0x00, pendingOwner)
@@ -447,9 +401,8 @@ library OwnableRolesLib {
     }
 
     /// @dev Returns the roles of `user`.
-    function _rolesOf(address user) internal view returns (uint256 roles) {
-        /// @solidity memory-safe-assembly
-        assembly {
+    function rolesOf(address user) internal view returns (uint256 roles) {
+        assembly ("memory-safe") {
             // Compute the role slot.
             mstore(0x0c, _ROLE_SLOT_SEED)
             mstore(0x00, user)
@@ -464,27 +417,27 @@ library OwnableRolesLib {
 
     /// @dev Marks a function as only callable by the owner.
     modifier onlyOwner() {
-        _checkOwner();
+        checkOwner();
         _;
     }
 
     /// @dev Marks a function as only callable by an account with `roles`.
     modifier onlyRoles(uint256 roles) {
-        _checkRoles(roles);
+        checkRoles(roles);
         _;
     }
 
     /// @dev Marks a function as only callable by the owner or by an account
     /// with `roles`. Checks for ownership first, then lazily checks for roles.
     modifier onlyOwnerOrRoles(uint256 roles) {
-        _checkOwnerOrRoles(roles);
+        checkOwnerOrRoles(roles);
         _;
     }
 
     /// @dev Marks a function as only callable by an account with `roles`
     /// or the owner. Checks for roles first, then lazily checks for ownership.
     modifier onlyRolesOrOwner(uint256 roles) {
-        _checkRolesOrOwner(roles);
+        checkRolesOrOwner(roles);
         _;
     }
 }

--- a/test/InitializableTester.t.sol
+++ b/test/InitializableTester.t.sol
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {GetSelectors} from "@diamond-test/helpers/GetSelectors.sol";
+import {ReinitializableDiamond} from "@diamond-test/mocks/ReinitializableDiamond.sol";
+import {DiamondCutFacet} from "@diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "@diamond/facets/DiamondLoupeFacet.sol";
+import {OwnableRolesFacet} from "@diamond/facets/OwnableRolesFacet.sol";
+import {ERC165Init} from "@diamond/initializers/ERC165Init.sol";
+import {MultiInit} from "@diamond/initializers/MultiInit.sol";
+import {OwnableInit} from "@diamond/initializers/OwnableInit.sol";
+import {ContextLib} from "@diamond/libraries/ContextLib.sol";
+import {FacetCut, FacetCutAction} from "@diamond/libraries/DiamondLib.sol";
+import {Initialized, InvalidInitialization} from "@diamond/libraries/InitializableLib.sol";
+
+/// @title InitializableTester
+/// @notice Tests for the initializable Diamond pattern
+contract InitializableTester is GetSelectors {
+    ReinitializableDiamond diamond;
+    DiamondCutFacet diamondCutFacet;
+    DiamondLoupeFacet diamondLoupeFacet;
+    OwnableRolesFacet ownableRolesFacet;
+    MultiInit multiInit;
+    OwnableInit ownableInit;
+    ERC165Init erc165Init;
+
+    FacetCut[] cuts;
+
+    function setUp() public {
+        // Deploy facets
+        diamondCutFacet = new DiamondCutFacet();
+        diamondLoupeFacet = new DiamondLoupeFacet();
+        ownableRolesFacet = new OwnableRolesFacet();
+
+        // Deploy initializers
+        multiInit = new MultiInit();
+        ownableInit = new OwnableInit();
+        erc165Init = new ERC165Init();
+
+        // Build facet cuts
+        cuts.push(
+            FacetCut({
+                facetAddress: address(diamondCutFacet),
+                action: FacetCutAction.Add,
+                functionSelectors: _getSelectors("DiamondCutFacet")
+            })
+        );
+        cuts.push(
+            FacetCut({
+                facetAddress: address(diamondLoupeFacet),
+                action: FacetCutAction.Add,
+                functionSelectors: _getSelectors("DiamondLoupeFacet")
+            })
+        );
+        cuts.push(
+            FacetCut({
+                facetAddress: address(ownableRolesFacet),
+                action: FacetCutAction.Add,
+                functionSelectors: _getSelectors("OwnableRolesFacet")
+            })
+        );
+
+        // Deploy diamond (uninitialized)
+        diamond = new ReinitializableDiamond();
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    INITIALIZATION TESTS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Diamond starts uninitialized with version 0
+    function testVersionIsZeroBeforeInit() public view {
+        assertEq(diamond.getInitializedVersion(), 0);
+    }
+
+    /// @notice Diamond is not in initializing state before init
+    function testNotInitializingBeforeInit() public view {
+        assertFalse(diamond.isInitializing());
+    }
+
+    /// @notice Initialize sets version to 1 and emits Initialized event
+    function testInitializeSetsVersionAndEmitsEvent() public {
+        (FacetCut[] memory facetCuts, address init, bytes memory initCalldata) = _buildInitArgs(address(this));
+
+        vm.expectEmit(false, false, false, true);
+        emit Initialized(1);
+
+        diamond.initialize(facetCuts, init, initCalldata);
+
+        assertEq(diamond.getInitializedVersion(), 1);
+        assertFalse(diamond.isInitializing());
+    }
+
+    /// @notice Second call to initialize reverts with InvalidInitialization
+    function testCannotInitializeTwice() public {
+        (FacetCut[] memory facetCuts, address init, bytes memory initCalldata) = _buildInitArgs(address(this));
+        diamond.initialize(facetCuts, init, initCalldata);
+
+        // Second initialization should revert
+        FacetCut[] memory emptyCuts = new FacetCut[](0);
+        vm.expectRevert(InvalidInitialization.selector);
+        diamond.initialize(emptyCuts, address(0), "");
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   REINITIALIZATION TESTS                     */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Reinitialize to version 2 after initial initialization
+    function testReinitializeToVersion2() public {
+        (FacetCut[] memory facetCuts, address init, bytes memory initCalldata) = _buildInitArgs(address(this));
+        diamond.initialize(facetCuts, init, initCalldata);
+
+        FacetCut[] memory emptyCuts = new FacetCut[](0);
+
+        vm.expectEmit(false, false, false, true);
+        emit Initialized(2);
+
+        diamond.reinitialize(emptyCuts, address(0), "", 2);
+
+        assertEq(diamond.getInitializedVersion(), 2);
+    }
+
+    /// @notice Cannot reinitialize with same version
+    function testCannotReinitializeWithSameVersion() public {
+        (FacetCut[] memory facetCuts, address init, bytes memory initCalldata) = _buildInitArgs(address(this));
+        diamond.initialize(facetCuts, init, initCalldata);
+
+        FacetCut[] memory emptyCuts = new FacetCut[](0);
+        vm.expectRevert(InvalidInitialization.selector);
+        diamond.reinitialize(emptyCuts, address(0), "", 1);
+    }
+
+    /// @notice Cannot reinitialize with lower version
+    function testCannotReinitializeWithLowerVersion() public {
+        (FacetCut[] memory facetCuts, address init, bytes memory initCalldata) = _buildInitArgs(address(this));
+        diamond.initialize(facetCuts, init, initCalldata);
+
+        FacetCut[] memory emptyCuts = new FacetCut[](0);
+        diamond.reinitialize(emptyCuts, address(0), "", 2);
+
+        vm.expectRevert(InvalidInitialization.selector);
+        diamond.reinitialize(emptyCuts, address(0), "", 1);
+    }
+
+    /// @notice Version increments correctly through multiple reinitializations
+    function testSequentialReinitializations() public {
+        (FacetCut[] memory facetCuts, address init, bytes memory initCalldata) = _buildInitArgs(address(this));
+        diamond.initialize(facetCuts, init, initCalldata);
+        assertEq(diamond.getInitializedVersion(), 1);
+
+        FacetCut[] memory emptyCuts = new FacetCut[](0);
+        diamond.reinitialize(emptyCuts, address(0), "", 2);
+        assertEq(diamond.getInitializedVersion(), 2);
+
+        diamond.reinitialize(emptyCuts, address(0), "", 5);
+        assertEq(diamond.getInitializedVersion(), 5);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                  DISABLE INITIALIZERS TESTS                  */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice disableInitializers prevents future initialization
+    function testDisableInitializersPreventsInit() public {
+        diamond.disableInitializers();
+
+        FacetCut[] memory emptyCuts = new FacetCut[](0);
+        vm.expectRevert(InvalidInitialization.selector);
+        diamond.initialize(emptyCuts, address(0), "");
+    }
+
+    /// @notice disableInitializers prevents future reinitialization
+    function testDisableInitializersPreventsReinit() public {
+        (FacetCut[] memory facetCuts, address init, bytes memory initCalldata) = _buildInitArgs(address(this));
+        diamond.initialize(facetCuts, init, initCalldata);
+
+        diamond.disableInitializers();
+
+        FacetCut[] memory emptyCuts = new FacetCut[](0);
+        vm.expectRevert(InvalidInitialization.selector);
+        diamond.reinitialize(emptyCuts, address(0), "", 2);
+    }
+
+    /// @notice disableInitializers sets version to max uint64
+    function testDisableInitializersSetsMaxVersion() public {
+        diamond.disableInitializers();
+        assertEq(diamond.getInitializedVersion(), type(uint64).max);
+    }
+
+    /// @notice disableInitializers emits Initialized with max uint64
+    function testDisableInitializersEmitsEvent() public {
+        vm.expectEmit(false, false, false, true);
+        emit Initialized(type(uint64).max);
+
+        diamond.disableInitializers();
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                     MULTI-INIT TESTS                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice MultiInit correctly initializes owner and ERC165 through initialize
+    function testMultiInitSetsOwnerAndInterfaces() public {
+        (FacetCut[] memory facetCuts, address init, bytes memory initCalldata) = _buildInitArgs(address(this));
+        diamond.initialize(facetCuts, init, initCalldata);
+
+        // Verify owner was set
+        OwnableRolesFacet ownable = OwnableRolesFacet(address(diamond));
+        assertEq(ownable.owner(), address(this));
+
+        // Verify ERC165 interfaces were registered
+        DiamondLoupeFacet loupe = DiamondLoupeFacet(address(diamond));
+        assertTrue(loupe.supportsInterface(0x01ffc9a7)); // ERC165
+        assertTrue(loupe.supportsInterface(0x7f5828d0)); // ERC173
+        assertTrue(loupe.supportsInterface(0x1f931c1c)); // IDiamondCut
+        assertTrue(loupe.supportsInterface(0x48e2b093)); // IDiamondLoupe
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        HELPERS                               */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function _buildInitArgs(address _owner)
+        internal
+        view
+        returns (FacetCut[] memory facetCuts_, address init_, bytes memory initCalldata_)
+    {
+        facetCuts_ = new FacetCut[](cuts.length);
+        for (uint256 i; i < cuts.length; ++i) {
+            facetCuts_[i] = cuts[i];
+        }
+
+        address[] memory initAddresses = new address[](2);
+        bytes[] memory initData = new bytes[](2);
+
+        initAddresses[0] = address(ownableInit);
+        initData[0] = abi.encodeWithSignature("initOwner(address)", _owner);
+
+        initAddresses[1] = address(erc165Init);
+        initData[1] = abi.encodeWithSignature("initERC165()");
+
+        init_ = address(multiInit);
+        initCalldata_ = abi.encodeWithSignature("multiInit(address[],bytes[])", initAddresses, initData);
+    }
+}

--- a/test/mocks/MockDiamond.sol
+++ b/test/mocks/MockDiamond.sol
@@ -3,13 +3,4 @@ pragma solidity ^0.8.20;
 
 import {Diamond, FacetCut} from "@diamond/Diamond.sol";
 
-contract MockDiamond is Diamond {
-    constructor(FacetCut[] memory _facetCuts, address _init, bytes memory _calldata)
-        payable
-        Diamond(_facetCuts, _init, _calldata)
-    {}
-
-    function _beforeDelegate() internal override {
-        // Add custom logic before delegatecall here
-    }
-}
+contract MockDiamond is Diamond {}

--- a/test/mocks/ReinitializableDiamond.sol
+++ b/test/mocks/ReinitializableDiamond.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Diamond, FacetCut} from "@diamond/Diamond.sol";
+import {DiamondLib} from "@diamond/libraries/DiamondLib.sol";
+import {InitializableLib} from "@diamond/libraries/InitializableLib.sol";
+
+contract ReinitializableDiamond is Diamond {
+    function reinitialize(FacetCut[] calldata _facetCuts, address _init, bytes calldata _calldata, uint64 _version)
+        external
+        payable
+    {
+        bytes32 s = InitializableLib.initializableSlot();
+        InitializableLib.preReinitializer(s, _version);
+
+        DiamondLib.diamondCutCalldata(_facetCuts, _init, _calldata);
+
+        InitializableLib.postReinitializer(s, _version);
+    }
+
+    function getInitializedVersion() external view returns (uint64) {
+        return InitializableLib.getInitializedVersion(InitializableLib.initializableSlot());
+    }
+
+    function isInitializing() external view returns (bool) {
+        return InitializableLib.isInitializing(InitializableLib.initializableSlot());
+    }
+
+    function disableInitializers() external {
+        InitializableLib.disableInitializers(InitializableLib.initializableSlot());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `InitializableLib` with versioned initialization guards (`initializer`, `reinitializer`, `disableInitializers`) adapted from Solady/OpenZeppelin
- Migrate `Diamond.sol` from constructor-based to external `initialize()` function, enabling proxy-friendly deployment
- Extract `OwnableInit` and `ERC165Init` from `DiamondInit` for granular, composable initialization via `MultiInit`
- Fix `postReinitializer` bug where version was stored without left-shifting, breaking the packed slot layout and causing incorrect version tracking
- Add 13 tests covering initialization, re-initialization prevention, version tracking, `disableInitializers`, and `MultiInit` composition
- Refactor `OwnableRolesLib`: rename functions and simplify assembly