### PR TITLE
Implement ERC165 interface support and initializers

### DIFF
--- a/script/DeployDiamond.s.sol
+++ b/script/DeployDiamond.s.sol
@@ -7,6 +7,8 @@ import {DiamondCutFacet} from "@diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "@diamond/facets/DiamondLoupeFacet.sol";
 import {ERC165Facet} from "@diamond/facets/ERC165Facet.sol";
 import {OwnableFacet} from "@diamond/facets/OwnableFacet.sol";
+import {DiamondInit} from "@diamond/initializers/DiamondInit.sol";
+import {ERC165Init} from "@diamond/initializers/ERC165Init.sol";
 import {MultiInit} from "@diamond/initializers/MultiInit.sol";
 import {OwnableInit} from "@diamond/initializers/OwnableInit.sol";
 import {ContextLib} from "@diamond/libraries/ContextLib.sol";
@@ -33,6 +35,8 @@ contract DeployDiamond is Script, GetSelectors {
 
         // Deploy initializer contracts
         address multiInit = address(new MultiInit());
+        address diamondInit = address(new DiamondInit());
+        address erc165Init = address(new ERC165Init());
         address ownableInit = address(new OwnableInit());
 
         // Create an array of FacetCut entries for standard facets
@@ -67,11 +71,17 @@ contract DeployDiamond is Script, GetSelectors {
         });
 
         // Build MultiInit arrays for granular initialization
-        address[] memory initAddresses = new address[](1);
-        bytes[] memory initData = new bytes[](1);
+        address[] memory initAddresses = new address[](3);
+        bytes[] memory initData = new bytes[](3);
 
-        initAddresses[0] = ownableInit;
-        initData[0] = abi.encodeWithSignature("initOwner(address)", ContextLib.msgSender());
+        initAddresses[0] = diamondInit;
+        initData[0] = abi.encodeWithSignature("init()");
+
+        initAddresses[1] = erc165Init;
+        initData[1] = abi.encodeWithSignature("init()");
+
+        initAddresses[2] = ownableInit;
+        initData[2] = abi.encodeWithSignature("init(address)", ContextLib.msgSender());
 
         // Deploy the Diamond contract with the facets and initialization args
         MockDiamond diamond = new MockDiamond();

--- a/src/facets/ERC165Facet.sol
+++ b/src/facets/ERC165Facet.sol
@@ -14,7 +14,7 @@ contract ERC165Facet {
     ///  uses less than 30,000 gas.
     /// @return `true` if the contract implements `_interfaceId` and
     ///  `_interfaceId` is not 0xffffffff, `false` otherwise
-    function supportsInterface(bytes4 _interfaceId) external pure returns (bool) {
+    function supportsInterface(bytes4 _interfaceId) external view returns (bool) {
         return ERC165Lib.supportsInterface(_interfaceId);
     }
 }

--- a/src/initializers/DiamondInit.sol
+++ b/src/initializers/DiamondInit.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {DiamondLib} from "@diamond/libraries/DiamondLib.sol";
+
+/// @title DiamondInit
+/// @notice Provides an initializer to set up the Diamond with ERC-165 support
+contract DiamondInit {
+    function init() public {
+        DiamondLib.registerInterface();
+    }
+}

--- a/src/initializers/ERC165Init.sol
+++ b/src/initializers/ERC165Init.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC165Lib} from "@diamond/libraries/ERC165Lib.sol";
+
+/// @title ERC165Init
+/// @notice Provides an initializer to register ERC165 interface support
+/// @author David Dada <daveproxy80@gmail.com> (https://github.com/dadadave80)
+contract ERC165Init {
+    /// @notice Initialize ERC165 interface registration
+    /// @dev Registers support for the ERC165 interface
+    function init() public {
+        ERC165Lib.registerInterface();
+    }
+}

--- a/src/initializers/OwnableInit.sol
+++ b/src/initializers/OwnableInit.sol
@@ -12,7 +12,8 @@ contract OwnableInit {
     /// @notice Initialize the contract owner.
     /// @dev This function is called during the diamond cut process to set up the owner.
     /// @param _owner The address to set as the contract owner.
-    function initOwner(address _owner) public {
+    function init(address _owner) public {
         OwnableLib.initializeOwner(_owner);
+        OwnableLib.registerInterface();
     }
 }

--- a/src/libraries/DiamondLib.sol
+++ b/src/libraries/DiamondLib.sol
@@ -115,14 +115,25 @@ struct Facet {
 }
 
 //*//////////////////////////////////////////////////////////////////////////
-//                              DIAMOND STORAGE
+//                                  STORAGE
 //////////////////////////////////////////////////////////////////////////*//
 
-// keccak256(abi.encode(uint256(keccak256("diamond.lib.storage")) - 1)) & ~bytes32(uint256(0xff));
+/// @dev `keccak256(abi.encode(uint256(keccak256("diamond.lib.storage")) - 1)) & ~bytes32(uint256(0xff)`.
 bytes32 constant DIAMOND_STORAGE_LOCATION = 0x6d5a93fec60e12d72b781fe97b2b5406e385b9eaa23d3ec2fbfa067f9d0dc000;
 
+/// @dev `keccak256(abi.encode(uint256(keccak256("diamond.lib.storage.ERC165")) - 1)) & ~bytes32(uint256(0xff))`.
+bytes32 constant ERC165_STORAGE_LOCATION = 0x9ca7f3e2e2bfb15fdf072b85dde92837cddacee6cf2f6b38cd06c9457c1c4200;
+
+/// @dev 0x1f931c1c is `type(IDiamondCut).interfaceId`.
+/// `keccak256(abi.encode(bytes4(0x1f931c1c), 0x9ca7f3e2e2bfb15fdf072b85dde92837cddacee6cf2f6b38cd06c9457c1c4200))`.
+bytes32 constant ERC165_MAP_ICUT_SLOT = 0xa0f80413692945aab97c6ef0328381ebb94e4b17a84d11ebf6b61f73435b6d7e;
+
+/// @dev 0x48e2b093 is `type(IDiamondLoupe).interfaceId`.
+/// `keccak256(abi.encode(bytes4(0x48e2b093), 0x9ca7f3e2e2bfb15fdf072b85dde92837cddacee6cf2f6b38cd06c9457c1c4200))`.
+bytes32 constant ERC165_MAP_ILOUPE_SLOT = 0x8b4e92bdfe8926212c580d8c12b81d3807ee1d50462b0f735541a0bd64c0003c;
+
 /// @notice Storage structure for managing facets and interface support in a Diamond (EIP-2535) proxy
-/// @dev Tracks function selector mappings, facet lists, and ERC-165 interface support
+/// @dev Tracks function selector mappings and facet lists
 /// @custom:storage-location erc7201:diamond.lib.storage
 struct DiamondStorage {
     /// @notice Maps each function selector to the facet address and selector’s position in that facet
@@ -148,6 +159,18 @@ library DiamondLib {
     function diamondStorage() internal pure returns (DiamondStorage storage ds_) {
         assembly {
             ds_.slot := DIAMOND_STORAGE_LOCATION
+        }
+    }
+
+    //*//////////////////////////////////////////////////////////////////////////
+    //                                ERC165 SETUP
+    //////////////////////////////////////////////////////////////////////////*//
+
+    /// @notice Registers support for IDiamondCut and IDiamondLoupe interfaces.
+    function registerInterface() internal {
+        assembly ("memory-safe") {
+            sstore(ERC165_MAP_ICUT_SLOT, true)
+            sstore(ERC165_MAP_ILOUPE_SLOT, true)
         }
     }
 

--- a/src/libraries/ERC165Lib.sol
+++ b/src/libraries/ERC165Lib.sol
@@ -1,44 +1,56 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+//*//////////////////////////////////////////////////////////////////////////
+//                                  STORAGE
+//////////////////////////////////////////////////////////////////////////*//
+
+/// @dev `keccak256(abi.encode(uint256(keccak256("diamond.lib.storage.ERC165")) - 1)) & ~bytes32(uint256(0xff))`.
+bytes32 constant ERC165_STORAGE_LOCATION = 0x9ca7f3e2e2bfb15fdf072b85dde92837cddacee6cf2f6b38cd06c9457c1c4200;
+
+/// @dev 0x01ffc9a7 is `type(IERC165).interfaceId`.
+/// `keccak256(abi.encode(bytes4(0x01ffc9a7), 0x9ca7f3e2e2bfb15fdf072b85dde92837cddacee6cf2f6b38cd06c9457c1c4200))`.
+bytes32 constant _ERC165_MAP_IERC165_SLOT = 0x124f8c425b7daf42b5736cba92e48ad5cb80b5f2f886a1fb5b276b3154f069f4;
+
+/// @notice Struct for storing ERC165 interface support information
+/// @dev Implements ERC-165 storage layout for tracking supported interface IDs
+/// @custom:storage-location erc7201:diamond.lib.storage.ERC165
+struct ERC165Storage {
+    mapping(bytes4 interfaceId => bool) supportedInterfaces;
+}
+
 /// @title ERC165Lib
 /// @author David Dada <daveproxy80@gmail.com> (https://github.com/dadadave80)
 /// @notice Library for checking ERC165 interface support
 library ERC165Lib {
-    /// @notice Query if a contract implements an interface
-    /// @param _interfaceId The interface identifier, as specified in ERC-165
-    /// @dev Interface identification is specified in ERC-165. This function
-    ///  uses less than 30,000 gas.
-    /// @return supported_ `true` if the contract implements `interfaceID` and
-    ///  `interfaceID` is not 0xffffffff, `false` otherwise
-    function supportsInterface(bytes4 _interfaceId) internal pure returns (bool supported_) {
+    /// @notice Get the ERC165 storage pointer
+    /// @return es_ Reference to the ERC165 storage struct
+    /// @dev Returns a reference to the ERC165 storage struct located at slot 0x9ca7f3e2e2bfb15fdf072b85dde92837cddacee6cf2f6b38cd06c9457c1c4200
+    function erc165Storage() internal pure returns (ERC165Storage storage es_) {
+        assembly {
+            es_.slot := ERC165_STORAGE_LOCATION
+        }
+    }
+
+    /// @notice Registers support for the ERC165 interface and other standard interfaces
+    /// @dev Marks this library as implementing ERC165 interface by setting the appropriate flag in storage.
+    ///  Must be called before using supportsInterface().
+    function registerInterface() internal {
         assembly ("memory-safe") {
-            // ERC165 interface IDs are 4 bytes, so we can shift right by 224 bits to get the first byte
-            switch shr(224, _interfaceId)
-            /// @dev type(ERC165).interfaceId
-            case 0x01ffc9a7 {
-                supported_ := true
-            }
-            /// @dev type(IERC173).interfaceId
-            case 0x7f5828d0 {
-                supported_ := true
-            }
-            /// @dev type(IDiamondCut).interfaceId
-            case 0x1f931c1c {
-                supported_ := true
-            }
-            /// @dev type(IDiamondLoupe).interfaceId
-            case 0x48e2b093 {
-                supported_ := true
-            }
-            /// @dev Invalid interface ID (ERC165 specifies that 0xffffffff is not a valid interface ID and must return false)
-            case 0xffffffff {
-                supported_ := false
-            }
-            /// @dev Invalid interface ID
-            default {
-                supported_ := false
-            }
+            sstore(_ERC165_MAP_IERC165_SLOT, true)
+        }
+    }
+
+    /// @notice Query if a contract implements an interface
+    /// @param _interfaceId The interface identifier, as specified in ERC-165 (bytes4)
+    /// @return supported_ `true` if the contract implements `interfaceID`, `false` otherwise
+    /// @dev Interface identification is specified in ERC-165. This function uses less than 30,000 gas.
+    function supportsInterface(bytes4 _interfaceId) internal view returns (bool supported_) {
+        assembly ("memory-safe") {
+            // Compute the storage key: keccak256(abi.encode(_interfaceId, ERC165_STORAGE_LOCATION))
+            mstore(0x00, _interfaceId)
+            mstore(0x20, ERC165_STORAGE_LOCATION)
+            supported_ := sload(keccak256(0x00, 0x40))
         }
     }
 }

--- a/src/libraries/OwnableLib.sol
+++ b/src/libraries/OwnableLib.sol
@@ -68,6 +68,16 @@ library OwnableLib {
     /// with both regular and upgradeable contracts.
     bytes32 internal constant _OWNER_SLOT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff74873927;
 
+    /// @dev The ERC165 storage slot is given by:
+    /// `keccak256(abi.encode(uint256(keccak256("diamond.lib.storage.ERC165")) - 1)) & ~bytes32(uint256(0xff))`.
+    bytes32 internal constant _ERC165_SLOT = 0x9ca7f3e2e2bfb15fdf072b85dde92837cddacee6cf2f6b38cd06c9457c1c4200;
+
+    /// @dev The ERC173 support mapping slot is given by:
+    /// 0x7f5828d0 is `type(IERC173).interfaceId`.
+    /// `keccak256(abi.encode(bytes4(0x7f5828d0), 0x9ca7f3e2e2bfb15fdf072b85dde92837cddacee6cf2f6b38cd06c9457c1c4200))`.
+    bytes32 internal constant _ERC165_MAP_IERC173_SLOT =
+        0xa572bbb13abe0b267cc0598d63b6a0e1b1511061fcb881c0bfcf34c8862d6431;
+
     /// The ownership handover slot of `newOwner` is given by:
     /// ```
     ///     mstore(0x00, or(shl(96, user), _HANDOVER_SLOT_SEED))
@@ -79,6 +89,13 @@ library OwnableLib {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                     INTERNAL FUNCTIONS                     */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Registers support for ERC173 interface in the ERC165 storage.
+    function registerInterface() internal {
+        assembly ("memory-safe") {
+            sstore(_ERC165_MAP_IERC173_SLOT, true)
+        }
+    }
 
     /// @dev Initializes the owner directly without authorization guard.
     /// This function must be called upon initialization,

--- a/test/InitializableTester.t.sol
+++ b/test/InitializableTester.t.sol
@@ -7,6 +7,9 @@ import {DiamondCutFacet} from "@diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "@diamond/facets/DiamondLoupeFacet.sol";
 import {ERC165Facet} from "@diamond/facets/ERC165Facet.sol";
 import {OwnableFacet} from "@diamond/facets/OwnableFacet.sol";
+import {DiamondInit} from "@diamond/initializers/DiamondInit.sol";
+import {ERC165Init} from "@diamond/initializers/ERC165Init.sol";
+import {MultiInit} from "@diamond/initializers/MultiInit.sol";
 import {OwnableInit} from "@diamond/initializers/OwnableInit.sol";
 import {ContextLib} from "@diamond/libraries/ContextLib.sol";
 import {FacetCut, FacetCutAction} from "@diamond/libraries/DiamondLib.sol";
@@ -20,6 +23,9 @@ contract InitializableTester is GetSelectors {
     DiamondLoupeFacet diamondLoupeFacet;
     ERC165Facet erc165Facet;
     OwnableFacet ownableFacet;
+    MultiInit multiInit;
+    DiamondInit diamondInit;
+    ERC165Init erc165Init;
     OwnableInit ownableInit;
 
     FacetCut[] cuts;
@@ -31,7 +37,10 @@ contract InitializableTester is GetSelectors {
         erc165Facet = new ERC165Facet();
         ownableFacet = new OwnableFacet();
 
-        // Deploy initializer
+        // Deploy initializers
+        multiInit = new MultiInit();
+        diamondInit = new DiamondInit();
+        erc165Init = new ERC165Init();
         ownableInit = new OwnableInit();
 
         // Build facet cuts
@@ -235,7 +244,20 @@ contract InitializableTester is GetSelectors {
             facetCuts_[i] = cuts[i];
         }
 
-        init_ = address(ownableInit);
-        initCalldata_ = abi.encodeWithSignature("initOwner(address)", _owner);
+        // Build MultiInit arrays for granular initialization
+        address[] memory initAddresses = new address[](3);
+        bytes[] memory initData = new bytes[](3);
+
+        initAddresses[0] = address(diamondInit);
+        initData[0] = abi.encodeWithSignature("init()");
+
+        initAddresses[1] = address(erc165Init);
+        initData[1] = abi.encodeWithSignature("init()");
+
+        initAddresses[2] = address(ownableInit);
+        initData[2] = abi.encodeWithSignature("init(address)", _owner);
+
+        init_ = address(multiInit);
+        initCalldata_ = abi.encodeWithSignature("multiInit(address[],bytes[])", initAddresses, initData);
     }
 }


### PR DESCRIPTION
Add support for the ERC165 interface by implementing storage management and registration functions. Introduce initializers for diamond contract setup, ensuring all necessary interfaces are registered during deployment. Update tests to validate the interface registration process.